### PR TITLE
add findCouplingRatio method

### DIFF
--- a/src/main/java/com/techhounds/houndutil/houndlib/swerve/CoaxialSwerveModule.java
+++ b/src/main/java/com/techhounds/houndutil/houndlib/swerve/CoaxialSwerveModule.java
@@ -38,6 +38,8 @@ public interface CoaxialSwerveModule {
         public DCMotor STEER_GEARBOX_REPR;
         public double DRIVE_MOI;
         public double STEER_MOI;
+
+        public double COUPLING_RATIO;
     }
 
     public double getDriveMotorPosition();

--- a/src/main/java/com/techhounds/houndutil/houndlib/swerve/CoaxialSwerveModule.java
+++ b/src/main/java/com/techhounds/houndutil/houndlib/swerve/CoaxialSwerveModule.java
@@ -22,6 +22,7 @@ public interface CoaxialSwerveModule {
 
         public double DRIVE_GEARING;
         public double STEER_GEARING;
+        public double COUPLING_RATIO;
         public double DRIVE_ENCODER_ROTATIONS_TO_METERS;
         public double STEER_ENCODER_ROTATIONS_TO_RADIANS;
         public double WHEEL_CIRCUMFERENCE;
@@ -38,8 +39,6 @@ public interface CoaxialSwerveModule {
         public DCMotor STEER_GEARBOX_REPR;
         public double DRIVE_MOI;
         public double STEER_MOI;
-
-        public double COUPLING_RATIO;
     }
 
     public double getDriveMotorPosition();

--- a/src/main/java/com/techhounds/houndutil/houndlib/swerve/KrakenCoaxialSwerveModule.java
+++ b/src/main/java/com/techhounds/houndutil/houndlib/swerve/KrakenCoaxialSwerveModule.java
@@ -10,6 +10,7 @@ import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.mechanisms.swerve.SwerveModule;
 import com.ctre.phoenix6.signals.AbsoluteSensorRangeValue;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.InvertedValue;
@@ -23,7 +24,9 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 
 @LoggedObject
@@ -256,5 +259,43 @@ public class KrakenCoaxialSwerveModule implements CoaxialSwerveModule {
     @Override
     public void setStateClosedLoop(SwerveModuleState state) {
         setStateInternal(state, false);
+    }
+
+    /**
+     * Find the coupling ratio (ratio of drive motor rotations to azimuth
+     * rotations) for module.
+     *
+     * @param volts     Voltage to send to angle motors to spin.
+     * @param automatic Attempt to automatically spin the modules.
+     * @return Average coupling ratio.
+     */
+    public double findCouplingRatio(double volts, boolean automatic) {
+        System.out.println("Stopping the Swerve Drive.");
+        driveMotor.setVoltage(0);
+        steerMotor.setVoltage(0);
+        Timer.delay(1);
+
+        System.out.println("Fetching the current absolute encoder and drive encoder position.");
+        Timer.delay(1);
+        Rotation2d startingAzimuthPosition = Rotation2d
+                .fromRotations(steerCanCoder.getAbsolutePosition().getValue());
+        double startingDriveMotorPosition = getDriveMotorPosition();
+
+        if (automatic) {
+            System.out.println("Rotating the module 360 degrees");
+            while (!Rotation2d.fromRotations(steerCanCoder.getAbsolutePosition().getValue())
+                    .equals(startingAzimuthPosition)) {
+                steerMotor.setVoltage(volts);
+            }
+
+            steerMotor.setVoltage(0);
+        } else {
+            DriverStation.reportWarning(
+                    "Spin the module 360 degrees now, you have 1 minute.\n",
+                    false);
+            Timer.delay(60);
+        }
+
+        return getDriveMotorPosition() - startingDriveMotorPosition;
     }
 }

--- a/src/main/java/com/techhounds/houndutil/houndlib/swerve/KrakenCoaxialSwerveModule.java
+++ b/src/main/java/com/techhounds/houndutil/houndlib/swerve/KrakenCoaxialSwerveModule.java
@@ -181,7 +181,9 @@ public class KrakenCoaxialSwerveModule implements CoaxialSwerveModule {
     @Override
     @Log
     public SwerveModulePosition getPosition() {
-        return new SwerveModulePosition(getDriveMotorPosition(), getWheelAngle());
+        return new SwerveModulePosition(
+                getDriveMotorPosition() - getWheelAngle().getRotations() * SWERVE_CONSTANTS.COUPLING_RATIO,
+                getWheelAngle());
     }
 
     @Override
@@ -259,43 +261,5 @@ public class KrakenCoaxialSwerveModule implements CoaxialSwerveModule {
     @Override
     public void setStateClosedLoop(SwerveModuleState state) {
         setStateInternal(state, false);
-    }
-
-    /**
-     * Find the coupling ratio (ratio of drive motor rotations to azimuth
-     * rotations) for module.
-     *
-     * @param volts     Voltage to send to angle motors to spin.
-     * @param automatic Attempt to automatically spin the modules.
-     * @return Average coupling ratio.
-     */
-    public double findCouplingRatio(double volts, boolean automatic) {
-        System.out.println("Stopping the Swerve Drive.");
-        driveMotor.setVoltage(0);
-        steerMotor.setVoltage(0);
-        Timer.delay(1);
-
-        System.out.println("Fetching the current absolute encoder and drive encoder position.");
-        Timer.delay(1);
-        Rotation2d startingAzimuthPosition = Rotation2d
-                .fromRotations(steerCanCoder.getAbsolutePosition().getValue());
-        double startingDriveMotorPosition = getDriveMotorPosition();
-
-        if (automatic) {
-            System.out.println("Rotating the module 360 degrees");
-            while (!Rotation2d.fromRotations(steerCanCoder.getAbsolutePosition().getValue())
-                    .equals(startingAzimuthPosition)) {
-                steerMotor.setVoltage(volts);
-            }
-
-            steerMotor.setVoltage(0);
-        } else {
-            DriverStation.reportWarning(
-                    "Spin the module 360 degrees now, you have 1 minute.\n",
-                    false);
-            Timer.delay(60);
-        }
-
-        return getDriveMotorPosition() - startingDriveMotorPosition;
     }
 }

--- a/src/main/java/com/techhounds/houndutil/houndlib/swerve/KrakenCoaxialSwerveModule.java
+++ b/src/main/java/com/techhounds/houndutil/houndlib/swerve/KrakenCoaxialSwerveModule.java
@@ -182,7 +182,12 @@ public class KrakenCoaxialSwerveModule implements CoaxialSwerveModule {
     @Log
     public SwerveModulePosition getPosition() {
         return new SwerveModulePosition(
-                getDriveMotorPosition() - getWheelAngle().getRotations() * SWERVE_CONSTANTS.COUPLING_RATIO,
+                // the position value of the drive motor is in rotations, so back out the
+                // correct number of rotations due to coupling between the drive and steer
+                // gears, then multiply back by circumference to get distance traveled in
+                // meters
+                (driveMotor.getPosition().getValue() - getWheelAngle().getRotations() * SWERVE_CONSTANTS.COUPLING_RATIO)
+                        * SWERVE_CONSTANTS.WHEEL_CIRCUMFERENCE,
                 getWheelAngle());
     }
 


### PR DESCRIPTION
Based off of [the same method in YAGSL](https://github.com/BroncBotz3481/YAGSL/blob/a5eb6d05e984a6b6527f8104cd874da06c35c4d1/swervelib/SwerveDriveTest.java#L194), but with extensive modifications to fit it into houndutil. I kept in most of the print statements even though they probably don't need to be there/should be using hooundlog instead, but I don't know how you want that done so I just left them there just in case.